### PR TITLE
DVcc: reflect hub4 Overrides/FeedInExcess settings for feedback_allowed

### DIFF
--- a/delegates/dvcc.py
+++ b/delegates/dvcc.py
@@ -944,6 +944,8 @@ class Dvcc(SystemCalcDelegate):
 			('com.victronenergy.vecan',	[
 				'/Link/ChargeVoltage',
 				'/Link/NetworkMode']),
+			('com.victronenergy.hub4', [
+				'/Overrides/FeedInExcess']),
 			('com.victronenergy.settings', [
 				 '/Settings/CGwacs/OvervoltageFeedIn',
 				 '/Settings/Services/Bol'])]
@@ -1306,7 +1308,9 @@ class Dvcc(SystemCalcDelegate):
 		# enabled'. This ignores other setups which allow feedback: hub-1.
 		return self.has_ess_assistant and self._multi.ac_connected and \
 			self._dbusmonitor.get_value('com.victronenergy.settings',
-				'/Settings/CGwacs/OvervoltageFeedIn') == 1
+				'/Settings/CGwacs/OvervoltageFeedIn') == 1 and \
+			self._dbusmonitor.get_value('com.victronenergy.hub4',
+				'/Overrides/FeedInExcess') != 1
 
 	def _update_solarchargers_and_vecan(self, has_bms, bms_charge_voltage, max_charge_current, feedback_allowed, stop_on_mcc0):
 		""" This function updates the solar chargers and VE.Can connected


### PR DESCRIPTION
For external control using hub4 Overrides/Setpoint path, it would be useful to preserve configured battery charge current limiting when the voltage level control has not been activated yet.

Example situation: Overrides/Setpoint is set to low value (e.g. zero) because the grid power price is too low, but there is extra PV power which should be reduced and battery is not full.

Honor com.victronenergy.hub4:/Overrides/FeedInExcess value in DVcc like for com.victronenergy.settings:/Settings/CGwacs/OvervoltageFeedIn.

This change extends custom control without altering settings tree to reduce mmc writes.