### PR TITLE
fix(motordrive): power inference

### DIFF
--- a/delegates/motordrive.py
+++ b/delegates/motordrive.py
@@ -39,7 +39,7 @@ class MotorDrive(SystemCalcDelegate):
 
 			# Not sure power is available, calculate it if not
 			newvalues[PREFIX + '/Power'] = self._dbusmonitor.get_value(service, '/Dc/0/Power')
-			if newvalues[PREFIX + '/Power'] is None:
+			if newvalues[PREFIX + '/Power'] is None and newvalues[PREFIX + '/Voltage'] is not None and newvalues[PREFIX + '/Current'] is not None:
 				newvalues[PREFIX + '/Power'] = newvalues[PREFIX + '/Voltage'] * newvalues[PREFIX + '/Current']
 
 			break

--- a/tests/motordrive_test.py
+++ b/tests/motordrive_test.py
@@ -40,3 +40,21 @@ class MotorDriveTest(TestSystemCalcBase):
 		self._check_values({
 			'/MotorDrive/Power': 120
 		})
+
+	def test_power_inference_with_invalid_values(self):
+		self._check_values({
+			'/MotorDrive/0/Service': 'com.victronenergy.motordrive.ttyX1',
+			'/MotorDrive/Voltage': 24,
+			'/MotorDrive/Current': 10,
+			'/MotorDrive/Power': 240,
+			'/MotorDrive/0/RPM': 1000
+		})
+
+		self._monitor.set_value('com.victronenergy.motordrive.ttyX1', '/Dc/0/Voltage', None)
+		self._monitor.set_value('com.victronenergy.motordrive.ttyX1', '/Dc/0/Current', None)
+		self._monitor.set_value('com.victronenergy.motordrive.ttyX1', '/Dc/0/Power', None)
+
+		self._update_values()
+		self._check_values({
+			'/MotorDrive/Power': None
+		})


### PR DESCRIPTION
Motordrive power calculations will cause dbus-systemcalc to crash if the voltage or the current is invalid.

Here is an example stacktrace:
```
2025-07-10 07:17:45.679260500 INFO:dbusmonitor:Found: com.victronenergy.motordrive.socketcan_can0, scanning and storing items
2025-07-10 07:17:45.697845500 INFO:dbusmonitor:       com.victronenergy.motordrive.socketcan_can0 has device instance 101
2025-07-10 07:17:46.258377500 exit_on_error: there was an exception. Printing stacktrace will be tried and then exit
2025-07-10 07:17:46.281472500 Traceback (most recent call last):
2025-07-10 07:17:46.284976500   File "/opt/victronenergy/dbus-systemcalc-py/ext/velib_python/ve_utils.py", line 24, in exit_on_error
2025-07-10 07:17:46.284985500     return func(*args, **kwargs)
2025-07-10 07:17:46.284988500            ^^^^^^^^^^^^^^^^^^^^^
2025-07-10 07:17:46.285160500   File "/opt/victronenergy/dbus-systemcalc-py/dbus_systemcalc.py", line 529, in _handletimertick
2025-07-10 07:17:46.285165500     self._updatevalues()
2025-07-10 07:17:46.285166500   File "/opt/victronenergy/dbus-systemcalc-py/dbus_systemcalc.py", line 1033, in _updatevalues
2025-07-10 07:17:46.285170500     m.update_values(newvalues)
2025-07-10 07:17:46.285289500   File "/opt/victronenergy/dbus-systemcalc-py/delegates/motordrive.py", line 43, in update_values
2025-07-10 07:17:46.285295500     newvalues[PREFIX + '/Power'] = newvalues[PREFIX + '/Voltage'] * newvalues[PREFIX + '/Current']
2025-07-10 07:17:46.285298500                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2025-07-10 07:17:46.285600500 TypeError: unsupported operand type(s) for *: 'NoneType' and 'NoneType'
2025-07-10 07:17:46.330143500 *** starting dbus-systemcalc-py ***
2025-07-10 07:17:48.873911500 -------- dbus_systemcalc, v2.217 is starting up --------
```